### PR TITLE
Switched to 5 column transform

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -38,31 +38,31 @@
                 compatible = "zmk,combos";
                 combo_esc {
                         timeout-ms = <50>;
-                        key-positions = <14 15>;
+                        key-positions = <11 12>;
                         bindings = <&kp ESC>;
                 };
 
                 combo_tab {
                         timeout-ms = <50>;
-                        key-positions = <15 16>;
+                        key-positions = <12 13>;
                         bindings = <&kp TAB>;
                 };
 
                 combo_enter {
                         timeout-ms = <50>;
-                        key-positions = <20 21>;
+                        key-positions = <17 18>;
                         bindings = <&kp ENTER>;
                 };
 
                 combo_backspace {
                         timeout-ms = <50>;
-                        key-positions = <19 20>;
+                        key-positions = <16 17>;
                         bindings = <&kp BACKSPACE>;
                 };
 
                 combo_gui {
                         timeout-ms = <50>;
-                        key-positions = <16 17>;
+                        key-positions = <13 14>;
                         bindings = <&kp LEFT_GUI>;
                 };
         };


### PR DESCRIPTION
This allows me to remove the numerous &none bindings in the keymap and more naturally count key positions when creating combos.